### PR TITLE
add '<scope>provided</scope>' to alfresco-repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Bring in Alfresco RAD so we get access to AlfrescoTestRunner classes -->


### PR DESCRIPTION
the amp size drops from 140MB to 0.1MB.